### PR TITLE
fix: url-http-create-request complains about multibytes characters

### DIFF
--- a/xml-rpc.el
+++ b/xml-rpc.el
@@ -574,10 +574,11 @@ or nil if called with ASYNC-CALLBACK-FUNCTION."
                                         " encoding=\"UTF-8\"?>\n"
                                         (with-temp-buffer
                                           (xml-print xml)
-                                          (when xml-rpc-allow-unicode-string
-                                            (encode-coding-region
-                                             (point-min) (point-max) 'utf-8))
-                                          (buffer-string))
+                                          (if xml-rpc-allow-unicode-string
+                                              (encode-coding-string
+                                               (buffer-substring-no-properties
+                                                (point-min) (point-max)) 'utf-8)
+                                              (buffer-substring-no-properties (point-min) (point-max))))
                                         "\n"))
               (url-mime-charset-string "utf-8;q=1, iso-8859-1;q=0.5")
               (url-request-coding-system xml-rpc-use-coding-system)


### PR DESCRIPTION
When the xml argument of the function xml-rpc-request contains
multibytes characters, the value stored in the variable
url-request-data is not properly encoded as a unibyte character
string.

The subsequent call to url-http-create-request fail with the error
message "Multibyte text in HTTP request: [...]", in the package url-http.

This bug occures with emacs 25.2 under a fresh debian 9.3 install,
and all packages from ELPA. I ran into the issue when trying to use the
emacs dokuwiki and dokuwiki-mode packages which interact with the
Dokuwiki XMLRPC API installed on a remote server.

It's probably the same bug which occures here:
https://github.com/proofit404/anaconda-mode/issues/189 .

This fix seams to fix the issue.