### PR TITLE
Add NonGNU ELPA badge to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,8 @@
-[[https://stable.melpa.org/#/xml-rpc][file:https://stable.melpa.org/packages/xml-rpc-badge.svg]] [[https://melpa.org/#/xml-rpc][file:https://melpa.org/packages/xml-rpc-badge.svg]] [[https://github.com/xml-rpc-el/xml-rpc-el/actions][https://github.com/xml-rpc-el/xml-rpc-el/workflows/CI/badge.svg]]
+[[http://github.com/xml-rpc-el/xml-rpc-el][https://elpa.nongnu.org/nongnu/xml-rpc.svg]]
+[[https://stable.melpa.org/#/xml-rpc][file:https://stable.melpa.org/packages/xml-rpc-badge.svg]]
+[[https://melpa.org/#/xml-rpc][file:https://melpa.org/packages/xml-rpc-badge.svg]]
+[[https://github.com/xml-rpc-el/xml-rpc-el/actions][https://github.com/xml-rpc-el/xml-rpc-el/workflows/CI/badge.svg]]
+
 * Commentary:
 
 This is an [[http://xmlrpc.com/][XML-RPC]] client implementation in elisp, capable of both synchronous and asynchronous method calls (using the url package's async retrieval functionality).


### PR DESCRIPTION
Hi!

We have now added this package to [NonGNU ELPA](http://elpa.nongnu.org/nongnu/xml-rpc.html) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others. This particular commit adds a badge, because it looks nice and is occasionally useful.

The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will be automatically when you bump the "Version" commentary header in this repository. You can bump the package version (thereby releasing a new version) at your convenience.

Please let me know if you have any questions about any of this.

Thanks!