### PR TITLE
Add .elpaignore for NonGNU ELPA

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,2 @@
+.github
+LICENSE


### PR DESCRIPTION
This adds the file `.elpaignore` which is used by NonGNU ELPA to skip adding some files to the package tarball.